### PR TITLE
Fix tiny typo

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -40,7 +40,7 @@ exports.createPages = ({ graphql, boundActionCreators }) => {
         }
 
         // Get an array of posts from the query result
-        const posts = _.get(result, "data.allMarkdownRemark.edges");
+        const blogPosts = _.get(result, "data.allMarkdownRemark.edges");
 
         // Create the blog index pages like `/blog`, `/blog/2`, `/blog/3`, etc.
         // Each page will have 10 blog posts and a link to the next and previous

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -3,7 +3,7 @@
 ## `gatsby-node.js`
 
 ```javascript
-import { paginate } from "gatsby-awesome-pagination";
+import { paginate, createPagePerItem } from "gatsby-awesome-pagination";
 ```
 
 ```javascript


### PR DESCRIPTION
Assumed this was meant to be `blogPosts` as it's referenced everywhere else. Almost not worth PRing for a single word, but thought I might as well.

Line 29 of the `examples.md` I think needs to be `title` and not `permalink` as well, but not sure on that one.

Cheers.