### PR TITLE
pathContext got deprecated warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ const BlogIndex = (props) => {
       {data.allMarkdownRemark.edges.map(edge => <PostItem item={edge.node}/>)}
       <div>
         {/* previousPageLink and nextPageLink were added by the plugin */ }
-        <Link to={props.pathContext.previousPagePath}>Previous</Link>
-        <Link to={props.pathContext.nextPagePath}>Next</Link>
+        <Link to={props.pageContext.previousPagePath}>Previous</Link>
+        <Link to={props.pageContext.nextPagePath}>Next</Link>
       </div>
     </div>
   )

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -102,8 +102,8 @@ Render posts like so:
 
 ```javascript
 const BlogIndex = props => {
-  const { pathContext } = props;
-  const { previousPagePath, nextPagePath } = pathContext;
+  const { pageContext } = props;
+  const { previousPagePath, nextPagePath } = pageContext;
 
   return (
     <div>
@@ -138,8 +138,8 @@ Then inside your component you can render links to the previous and next posts.
 
 ```javascript
 const BlogPost = props => {
-  const { pathContext, data } = props;
-  const { previousPagePath, nextPagePath, previousPageItem, nextPageItem } = pathContext;
+  const { pageContext, data } = props;
+  const { previousPagePath, nextPagePath, previousPageItem, nextPageItem } = pageContext;
   const { post } = data;
 
   return (
@@ -148,12 +148,12 @@ const BlogPost = props => {
       <div dangerouslySetInnerHTML={{ __html: post.html }} />
       <div>
         {previousPagePath ? (
-          <Link to={pathContext.previousPagePath}>
+          <Link to={pageContext.previousPagePath}>
             {previousPageItem.frontmatter.title}
           </Link>
         ) : null}
         {nextPagePath ? (
-          <Link to={pathContext.nextPagePath}>
+          <Link to={pageContext.nextPagePath}>
             {nextPageItem.frontmatter.title}
           </Link>
         ) : null}


### PR DESCRIPTION
Thank you for good plugin.

I found this document use `pathContext` but that deprecated.
https://www.gatsbyjs.org/docs/migrating-from-v1-to-v2/#rename-pathcontext-to-pagecontext