### PR TITLE
Adding README clarification for pathPrefix arg. …

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ In addition to the arguments above, `paginate()` also supports:
 
 * `itemsPerPage`* - An integer, how many items should be displayed on each page
 * `itemsPerFirstPage` - An integer, how many items should be displayed on the **first** page
-* `pathPrefix`* - A string, the path like `/blog` (or string returning function), to which `/2`, `/3`, etc will be added
+* `pathPrefix`* - A string, the path like `/blog` (or string returning function), to which `/2`, `/3`, etc will be added. Cannot be an empty string.
 * `context` - A base context object which is extended with the pagination context values
 
 Example:


### PR DESCRIPTION
… It was marked required but did not specify that it could not be empty string. I do not need the ability to leave it empty. But the plugin ate the error, only "createPage" threw one (below).

## To Reproduce
I was using paginate in gatsby-node.js
In the Config, I left the ***pathPrefix*** blank, eg: ```pathPrefix: "",```
I ran gatsby develop and got an Error 11323 from **createPage**:
>Your site's "gatsby-node.js" must set the page path when creating a page.
>
>The page object passed to createPage:
```javascript
{
    "path": "",
    "component": "C:\\Users\\EdPike365\\code\\gatsby-rich-text\\src\\templates\\blog-posts.js",
    "context": {
        "basePath": "",
        "paginationPath": "",
        "pageNumber": 0,
        "humanPageNumber": 1,
        "skip": 0,
        "limit": 7,
        "numberOfPages": 1,
        "previousPagePath": "",
        "nextPagePath": ""
    }
}
```
## Expected Behaviour
Plugin code should throw an error when it encounters an empty required string. 

## Additional Context
I tried to debug the code where you create a "wrapped" config object, but the code seemed to magically flake. I barely know node and I don't know Lodash at all so that is probably the problem on my end. I come from planet Java, JSP City. I'll get better...
This is my first PR anywhere, ever! Thanks for making the plugin.

